### PR TITLE
Add skyfield-based orbit angle generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# 364
+# 364 Calendar Tools
+
+This repository contains a simple HTML wheel for a 13‑month calendar and
+Python utilities for computing planetary positions relative to a custom
+"day one"—the first Monday following the June solstice.
+
+## Requirements
+
+Install the dependencies from `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+The first run of the Python scripts will attempt to download the JPL
+`de421.bsp` ephemeris. Internet access is required for this download.
+
+## Generating Orbital Angles
+
+Run the `generate_orbit_angles.py` script to compute the daily ecliptic
+longitude of each planet (relative to the Sun's position on day one) for
+one year:
+
+```bash
+python generate_orbit_angles.py
+```
+
+The results are saved to `orbit_angles.csv`.

--- a/generate_orbit_angles.py
+++ b/generate_orbit_angles.py
@@ -1,0 +1,64 @@
+import pandas as pd
+from datetime import datetime, timedelta
+from skyfield.api import load
+from skyfield import almanac
+
+# Planets to track
+PLANETS = [
+    'mercury',
+    'venus',
+    'earth',  # for reference
+    'mars',
+    'jupiter barycenter',
+    'saturn barycenter',
+    'uranus barycenter',
+    'neptune barycenter',
+]
+
+def summer_solstice_first_monday(eph, ts, year):
+    """Return Time of the first Monday after the June solstice."""
+    t0 = ts.utc(year, 6, 20)
+    t1 = ts.utc(year, 7, 1)
+    t, y = almanac.find_discrete(t0, t1, almanac.seasons(eph))
+    solstice = None
+    for ti, yi in zip(t, y):
+        if yi == almanac.SUMMER:
+            solstice = ti.utc_datetime().date()
+            break
+    if solstice is None:
+        raise ValueError('Could not determine summer solstice')
+
+    d = datetime.combine(solstice, datetime.min.time())
+    while d.weekday() != 0:  # 0 = Monday
+        d += timedelta(days=1)
+    return ts.utc(d.year, d.month, d.day)
+
+
+def compute_orbits(year=2024):
+    ts = load.timescale()
+    eph = load('de421.bsp')
+
+    start_time = summer_solstice_first_monday(eph, ts, year)
+
+    sun = eph['sun']
+    start_long = sun.at(start_time).ecliptic_position().longitude.degrees
+
+    days = 364
+    records = []
+    for day in range(days):
+        t = start_time + day
+        row = {'day': day}
+        for name in PLANETS:
+            body = eph[name]
+            lon = body.at(t).ecliptic_position().longitude.degrees
+            rel_angle = (lon - start_long) % 360
+            row[name] = rel_angle
+        records.append(row)
+
+    df = pd.DataFrame(records)
+    return df
+
+if __name__ == '__main__':
+    df = compute_orbits()
+    df.to_csv('orbit_angles.csv', index=False)
+    print('Saved orbit_angles.csv')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+skyfield
+numpy
+pandas


### PR DESCRIPTION
## Summary
- detail Python dependencies in `requirements.txt`
- document how to generate planetary data in `README.md`
- implement `generate_orbit_angles.py` to compute orbital positions for a year

## Testing
- `pip install pandas --user`
- `python generate_orbit_angles.py` *(fails: cannot download de421.bsp because of network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684fa72e7c908330858781e9b39184bc