### PR TITLE
Add CLI ephemeris scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Time Pope Terminal Calendar
+
+This repository contains a CLI-first web project implementing a symbolic 360° orbit system and a 364-day ritual calendar.
+
+## Structure
+
+```
+calendar-cli/
+  cli/            # Node CLI scripts
+  ui/             # Optional browser UI
+  data/           # Generated ephemeris files
+```
+
+## Setup
+
+```
+cd calendar-cli
+npm install
+node cli/index.js compute 2025  # generate ephemeris for the year
+```
+
+Open `ui/index.html` in a browser to view the generated data.

--- a/calendar-cli/.gitignore
+++ b/calendar-cli/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/calendar-cli/README.md
+++ b/calendar-cli/README.md
@@ -1,0 +1,14 @@
+# Time Pope Terminal Calendar
+
+This project is a CLI-first calendrical system based on a symbolic 360° orbit. It normalizes planetary year cycles and implements a 364-day ritual calendar. The CLI can download ephemeris data and compute planetary positions. The optional UI provides a simple browser-based view.
+
+## Setup
+
+Install dependencies and run the CLI:
+
+```bash
+npm install
+node cli/index.js
+```
+
+To open the optional web interface, open `ui/index.html` in a browser.

--- a/calendar-cli/cli/ephemeris.js
+++ b/calendar-cli/cli/ephemeris.js
@@ -1,0 +1,42 @@
+const Astronomy = require('astronomy-engine');
+
+function summerSolsticeFirstMonday(year) {
+  const seasons = Astronomy.Seasons(year);
+  const solstice = seasons.jun_solstice.date;
+  const d = new Date(Date.UTC(solstice.getUTCFullYear(), solstice.getUTCMonth(), solstice.getUTCDate()));
+  while (d.getUTCDay() !== 1) {
+    d.setUTCDate(d.getUTCDate() + 1);
+  }
+  return new Astronomy.AstroTime(d);
+}
+
+function computeOrbits(year = new Date().getUTCFullYear()) {
+  const start = summerSolsticeFirstMonday(year);
+  const sunVec = Astronomy.GeoVector(Astronomy.Body.Sun, start, false);
+  const sunLon = Astronomy.Ecliptic(sunVec).elon;
+  const planets = [
+    { body: Astronomy.Body.Mercury, name: 'mercury' },
+    { body: Astronomy.Body.Venus, name: 'venus' },
+    { body: Astronomy.Body.Earth, name: 'earth' },
+    { body: Astronomy.Body.Mars, name: 'mars' },
+    { body: Astronomy.Body.Jupiter, name: 'jupiter' },
+    { body: Astronomy.Body.Saturn, name: 'saturn' },
+    { body: Astronomy.Body.Moon, name: 'moon' }
+  ];
+  const days = 364;
+  const records = [];
+  for (let day = 0; day < days; day++) {
+    const t = start.AddDays(day);
+    const row = { day };
+    for (const p of planets) {
+      const vec = Astronomy.GeoVector(p.body, t, false);
+      const lon = Astronomy.Ecliptic(vec).elon;
+      const rel = (lon - sunLon + 360) % 360;
+      row[p.name] = Number(rel.toFixed(6));
+    }
+    records.push(row);
+  }
+  return { start: start.date.toISOString(), records };
+}
+
+module.exports = { computeOrbits };

--- a/calendar-cli/cli/index.js
+++ b/calendar-cli/cli/index.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { computeOrbits } = require('./ephemeris');
+
+function usage() {
+  console.log(`Usage: node cli/index.js compute [year]\n`);
+}
+
+const [,, cmd, arg] = process.argv;
+if (cmd === 'compute') {
+  const year = parseInt(arg || new Date().getUTCFullYear(), 10);
+  const result = computeOrbits(year);
+  const outDir = path.join(__dirname, '..', 'data');
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+  const outFile = path.join(outDir, `orbits-${year}.json`);
+  fs.writeFileSync(outFile, JSON.stringify(result, null, 2));
+  console.log(`Saved ${outFile}`);
+} else {
+  usage();
+  process.exit(1);
+}

--- a/calendar-cli/package-lock.json
+++ b/calendar-cli/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "calendar-cli",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calendar-cli",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "astronomy-engine": "^2.1.19"
+      }
+    },
+    "node_modules/astronomy-engine": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/astronomy-engine/-/astronomy-engine-2.1.19.tgz",
+      "integrity": "sha512-8yWKNf7UeNbH458h3sAJ6ZgAjE5jTXp/mNNRFoC20j2SHwZIjAQeEsBB2Q3uCFRaTCCJRv33K2XhkhZQMXoX6w==",
+      "license": "MIT"
+    }
+  }
+}

--- a/calendar-cli/package.json
+++ b/calendar-cli/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "calendar-cli",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "astronomy-engine": "^2.1.19"
+  }
+}

--- a/calendar-cli/ui/calendar.js
+++ b/calendar-cli/ui/calendar.js
@@ -1,0 +1,8 @@
+fetch('../data/orbits-' + new Date().getUTCFullYear() + '.json')
+  .then(r => r.json())
+  .then(data => {
+    document.getElementById('output').textContent = JSON.stringify(data.records.slice(0, 5), null, 2) + '\n...';
+  })
+  .catch(() => {
+    document.getElementById('output').textContent = 'Run `node cli/index.js compute` first.';
+  });

--- a/calendar-cli/ui/index.html
+++ b/calendar-cli/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Time Pope Calendar</title>
+  <script src="calendar.js" defer></script>
+</head>
+<body>
+  <h1>Time Pope Calendar Viewer</h1>
+  <pre id="output"></pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold a new `calendar-cli` project with npm
- implement ephemeris calculations and CLI entry point
- add minimal browser UI and root README instructions

## Testing
- `node cli/index.js compute 2027`

------
https://chatgpt.com/codex/tasks/task_e_6850a8c9445c8330b0736b146975b140