### PR TITLE
Extend CLI for gregorian calendar data

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ calendar-cli/
 ```
 cd calendar-cli
 npm install
-node cli/index.js compute 2025  # generate ephemeris for the year
+node cli/index.js compute 2025 ritual     # 364-day ritual calendar
+node cli/index.js compute 2025 gregorian  # 365-day Gregorian calendar
 ```
 
 Open `ui/index.html` in a browser to view the generated data.

--- a/calendar-cli/README.md
+++ b/calendar-cli/README.md
@@ -8,7 +8,10 @@ Install dependencies and run the CLI:
 
 ```bash
 npm install
-node cli/index.js
+# generate ritual calendar data
+node cli/index.js compute 2025 ritual
+# generate Gregorian calendar data
+node cli/index.js compute 2025 gregorian
 ```
 
 To open the optional web interface, open `ui/index.html` in a browser.

--- a/calendar-cli/cli/index.js
+++ b/calendar-cli/cli/index.js
@@ -4,16 +4,18 @@ const path = require('path');
 const { computeOrbits } = require('./ephemeris');
 
 function usage() {
-  console.log(`Usage: node cli/index.js compute [year]\n`);
+  console.log(`Usage: node cli/index.js compute [year] [calendar]\n`);
+  console.log('  calendar = ritual (default) or gregorian');
 }
 
-const [,, cmd, arg] = process.argv;
+const [,, cmd, argYear, argCal] = process.argv;
 if (cmd === 'compute') {
-  const year = parseInt(arg || new Date().getUTCFullYear(), 10);
-  const result = computeOrbits(year);
+  const year = parseInt(argYear || new Date().getUTCFullYear(), 10);
+  const calendar = (argCal === 'gregorian') ? 'gregorian' : 'ritual';
+  const result = computeOrbits(year, calendar);
   const outDir = path.join(__dirname, '..', 'data');
   if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
-  const outFile = path.join(outDir, `orbits-${year}.json`);
+  const outFile = path.join(outDir, `orbits-${calendar}-${year}.json`);
   fs.writeFileSync(outFile, JSON.stringify(result, null, 2));
   console.log(`Saved ${outFile}`);
 } else {


### PR DESCRIPTION
## Summary
- add constant for galactic center (Sagittarius A*)
- support computing orbits for 365‑day Gregorian or 364‑day ritual calendar
- output data file name includes calendar type
- document new CLI usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850aaffde3c8330a8d40ad5fe03f6d5