### PR TITLE
Start calendars on solstice Monday

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Time Pope Terminal Calendar
 
-This repository contains a CLI-first web project implementing a symbolic 360° orbit system and a 364-day ritual calendar.
+This repository contains a CLI-first web project implementing a symbolic 360° orbit system and a 364-day ritual calendar. Both calendar modes start on the first Monday after the summer solstice.
 
 ## Structure
 
@@ -20,4 +20,4 @@ node cli/index.js compute 2025 ritual     # 364-day ritual calendar
 node cli/index.js compute 2025 gregorian  # 365-day Gregorian calendar
 ```
 
-Open `ui/index.html` in a browser to view the generated data.
+The ritual calendar uses 13 months with 7-day weeks and 4 weeks per month. The CLI output includes `month`, `week` and `weekday` fields for this mode. Open `ui/index.html` in a browser to view the generated data.

--- a/calendar-cli/README.md
+++ b/calendar-cli/README.md
@@ -1,6 +1,6 @@
 # Time Pope Terminal Calendar
 
-This project is a CLI-first calendrical system based on a symbolic 360° orbit. It normalizes planetary year cycles and implements a 364-day ritual calendar. The CLI can download ephemeris data and compute planetary positions. The optional UI provides a simple browser-based view.
+This project is a CLI-first calendrical system based on a symbolic 360° orbit. It normalizes planetary year cycles and implements a 364-day ritual calendar. Calendar data for both modes begins on the first Monday after the summer solstice. The CLI can download ephemeris data and compute planetary positions. The optional UI provides a simple browser-based view.
 
 ## Setup
 
@@ -14,4 +14,4 @@ node cli/index.js compute 2025 ritual
 node cli/index.js compute 2025 gregorian
 ```
 
-To open the optional web interface, open `ui/index.html` in a browser.
+The ritual calendar divides the 364-day year into 13 months with 7-day weeks and 4 weeks per month. The JSON output includes `month`, `week` and `weekday` fields. To open the optional web interface, open `ui/index.html` in a browser.

--- a/calendar-cli/ui/calendar.js
+++ b/calendar-cli/ui/calendar.js
@@ -1,7 +1,13 @@
-fetch('../data/orbits-' + new Date().getUTCFullYear() + '.json')
-  .then(r => r.json())
+const year = new Date().getUTCFullYear();
+function load(file) {
+  return fetch(file).then(r => r.ok ? r.json() : Promise.reject());
+}
+
+load('../data/orbits-ritual-' + year + '.json')
+  .catch(() => load('../data/orbits-gregorian-' + year + '.json'))
   .then(data => {
-    document.getElementById('output').textContent = JSON.stringify(data.records.slice(0, 5), null, 2) + '\n...';
+    const out = { start: data.start, waitDays: data.waitDays, sample: data.records.slice(0, 5) };
+    document.getElementById('output').textContent = JSON.stringify(out, null, 2) + '\n...';
   })
   .catch(() => {
     document.getElementById('output').textContent = 'Run `node cli/index.js compute` first.';


### PR DESCRIPTION
## Summary
- align both calendars to start on the first Monday after the summer solstice
- add month/week/weekday info for the 13-month ritual calendar
- expose `waitDays` from solstice to start date
- improve UI data loading
- update documentation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850ade8465c833095f41facb7451339