### PR TITLE
Clarify how to serve the calendar UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@ node cli/index.js compute 2025 gregorian  # 365-day Gregorian calendar
 ```
 
 The ritual calendar uses 13 months with 7-day weeks and 4 weeks per month. The CLI output includes `month`, `week` and `weekday` fields for this mode. Open `ui/index.html` in a browser to view the generated data.
+
+### Launching the browser demo
+
+After generating the JSON files, serve the `calendar-cli` directory so the
+browser can fetch them. A quick way is:
+
+```bash
+cd calendar-cli
+python3 -m http.server
+```
+
+Then visit <http://localhost:8000/ui/> in your browser. If you open the HTML
+file directly from disk you may see the message `Run \`node cli/index.js
+compute\` first` because the browser cannot fetch the JSON files without an HTTP
+server.

--- a/calendar-cli/README.md
+++ b/calendar-cli/README.md
@@ -14,4 +14,14 @@ node cli/index.js compute 2025 ritual
 node cli/index.js compute 2025 gregorian
 ```
 
-The ritual calendar divides the 364-day year into 13 months with 7-day weeks and 4 weeks per month. The JSON output includes `month`, `week` and `weekday` fields. To open the optional web interface, open `ui/index.html` in a browser.
+The ritual calendar divides the 364-day year into 13 months with 7-day weeks and 4 weeks per month. The JSON output includes `month`, `week` and `weekday` fields.
+
+### Viewing the data in a browser
+
+Serve the `calendar-cli` directory so the static page can load the generated JSON files. For example:
+
+```bash
+python3 -m http.server
+```
+
+Then open <http://localhost:8000/ui/> in your browser. Opening `index.html` directly from disk won't work because the page uses `fetch` to request the JSON data.


### PR DESCRIPTION
## Summary
- document serving the browser interface with `python3 -m http.server`
- mention that opening the HTML file directly will not load the data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850b15c2a588330810f14818c8fe015